### PR TITLE
startMu is not unlocked

### DIFF
--- a/group.go
+++ b/group.go
@@ -33,6 +33,7 @@ type Group struct {
 func (g *Group) Add(s Server) {
 	g.startedMu.RLock()
 	if g.startedMu.started {
+		g.startedMu.RUnlock()
 		return
 	}
 	g.startedMu.RUnlock()


### PR DESCRIPTION
Fixed `g.startedMu` remained RLocked when calling `Group.Add()` with `g.startedMu.started = true`.