### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,11 +16,13 @@ jobs:
       matrix:
         version:
           - 1.18.10
-          - 1.19.9
-          - 1.20.4
+          - 1.19.13
+          - 1.20.14
+          - 1.21.7
+          - 1.22.0
 
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4.1.1
 
       - name: Test
         run: |

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/110y/servergroup
 
 go 1.20
 
-require golang.org/x/sys v0.8.0
+require golang.org/x/sys v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
-golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
- Update Go to 1.22.0
- Update Go versions on CI
- Update golang.org/x/sys to v0.17.0
- Update actions/checkout to v4.1.1