### PR TITLE
test: introduce go.uber.org/goleak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/110y/servergroup
 
 go 1.20
 
-require golang.org/x/sys v0.17.0
+require (
+	go.uber.org/goleak v1.3.0
+	golang.org/x/sys v0.17.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/group_test.go
+++ b/group_test.go
@@ -7,8 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/goleak"
+
 	"github.com/110y/servergroup"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestGroup(t *testing.T) {
 	t.Parallel()
@@ -33,7 +39,7 @@ func TestGroup(t *testing.T) {
 		return nil
 	}
 
-	stop := func(ctx context.Context) error {
+	stop := func(_ context.Context) error {
 		return nil
 	}
 
@@ -93,7 +99,7 @@ func TestGroupErrorStop(t *testing.T) {
 			<-ctx.Done()
 			return nil
 		},
-		stop: func(ctx context.Context) error {
+		stop: func(_ context.Context) error {
 			return errors.New("failed to stop server")
 		},
 	}


### PR DESCRIPTION
- Just introduce `go.uber.org/goleak` to prevent an unexpected Goroutine leaks.